### PR TITLE
package.json: use http git protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/dannycoates/scrypt-hash.git"
+    "url": "https://github.com/dannycoates/scrypt-hash.git"
   },
   "keywords": [
     "scrypt",


### PR DESCRIPTION
git protocol is a pain in many environments, http is the proxy friendly alternative