### PR TITLE
update nan; test on 8,10,11; drop 0.10,0.12; use Buffer.from; add package-lock.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: node_js
 
 node_js:
- - '0.10'
- - '0.12'
  - '4'
  - '6'
+ - '8'
+ - '10'
+ - '11'
  - 'stable'
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ node bindings for crypto_scrypt from [scrypt](http://www.tarsnap.com/scrypt.html
 ```js
 var scrypt = require('scrypt-hash')
 
-var password = Buffer('aprettybadpassword')
-var salt = Buffer('adashofsalt')
+var password = Buffer.from('aprettybadpassword')
+var salt = Buffer.from('adashofsalt', 'utf8')
 var N = 1024 * 64
 var r = 8
 var p = 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "scrypt-hash",
+  "version": "1.1.14",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "nan": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "bindings": "1.2.1",
-    "nan": "2.4.0"
+    "nan": "2.11.1"
   },
   "author": "Danny Coates",
   "license": "BSD",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 var scrypt = require('./')
 
-var K1 = Buffer('f84913e3d8e6d624689d0a3e9678ac8dcc79d2c2f3d9641488cd9d6ef6cd83dd', 'hex')
-var salt = Buffer('identity.mozilla.com/picl/v1/scrypt')
+var K1 = Buffer.from('f84913e3d8e6d624689d0a3e9678ac8dcc79d2c2f3d9641488cd9d6ef6cd83dd', 'hex')
+var salt = Buffer.from('identity.mozilla.com/picl/v1/scrypt', 'utf8')
 
 console.time('native')
 scrypt(


### PR DESCRIPTION
A first stab at refresh for node 10, passes, but not really complete. There's a lot of deprecation warnings there, some from within nan that maybe fixed in a future release of nan. The change to use `Buffer.from` means `0.10` and `0.12` are broken, so I removed them, but, well, it's time.